### PR TITLE
Add project management pages

### DIFF
--- a/actions/projects/delete-project.ts
+++ b/actions/projects/delete-project.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { getProjectById } from "@/data/projects";
+import { requireUser } from "@/hooks/require-user";
+
+export const deleteProject = async (id: string) => {
+  const session = await requireUser();
+
+  const existingProject = await getProjectById(id, session.user.id as string);
+
+  if (!existingProject) {
+    return { error: "Project not found!" };
+  }
+
+  await db.project.delete({
+    where: { id },
+  });
+
+  return { success: `Project "${existingProject.name}" deleted!` };
+};

--- a/actions/projects/update-project.ts
+++ b/actions/projects/update-project.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import * as z from "zod";
+
+import { db } from "@/lib/db";
+import { CreateProjectSchema } from "@/schemas";
+import { getProjectById } from "@/data/projects";
+import { requireUser } from "@/hooks/require-user";
+
+export const updateProject = async (
+  id: string,
+  values: z.infer<typeof CreateProjectSchema>
+) => {
+  const validatedFields = CreateProjectSchema.safeParse(values);
+
+  if (!validatedFields.success) {
+    return { error: "Neplatné záznamy!" };
+  }
+
+  const session = await requireUser();
+
+  const existingProject = await getProjectById(id, session.user.id as string);
+
+  if (!existingProject) {
+    return { error: "Project not found!" };
+  }
+
+  const {
+    name,
+    description,
+    startDate,
+    endDate,
+    deadlineDate,
+    customerId,
+    priority,
+  } = validatedFields.data;
+
+  await db.project.update({
+    where: { id },
+    data: {
+      name,
+      description,
+      start_date: startDate,
+      end_date: endDate,
+      deadline_date: deadlineDate,
+      customerId,
+      priority,
+    },
+  });
+
+  return { success: `Project "${name}" updated!` };
+};

--- a/app/(protected)/projects/[projectId]/delete/page.tsx
+++ b/app/(protected)/projects/[projectId]/delete/page.tsx
@@ -1,0 +1,20 @@
+import { requireUser } from '@/hooks/require-user';
+import { getProjectById } from '@/data/projects';
+import { deleteProject } from '@/actions/projects/delete-project';
+import { redirect } from 'next/navigation';
+
+interface DeleteProjectPageProps {
+  params: { projectId: string };
+}
+
+export default async function DeleteProjectPage({ params }: DeleteProjectPageProps) {
+  const session = await requireUser();
+  const project = await getProjectById(params.projectId, session.user.id as string);
+
+  if (!project) {
+    redirect('/dashboard');
+  }
+
+  await deleteProject(project.id);
+  redirect('/dashboard');
+}

--- a/app/(protected)/projects/[projectId]/page.tsx
+++ b/app/(protected)/projects/[projectId]/page.tsx
@@ -1,0 +1,35 @@
+import { getProjectById } from '@/data/projects';
+import { requireUser } from '@/hooks/require-user';
+import { notFound } from 'next/navigation';
+import React from 'react';
+
+interface ProjectPageProps {
+  params: { projectId: string };
+}
+
+export default async function ProjectPage({ params }: ProjectPageProps) {
+  const session = await requireUser();
+  const project = await getProjectById(params.projectId, session.user.id as string);
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-4">{project.name}</h1>
+      {project.description && <p className="mb-2">{project.description}</p>}
+      <div className="text-sm text-muted-foreground space-y-1">
+        {project.start_date && (
+          <p>Start: {project.start_date.toDateString()}</p>
+        )}
+        {project.end_date && <p>End: {project.end_date.toDateString()}</p>}
+        {project.deadline_date && (
+          <p>Deadline: {project.deadline_date.toDateString()}</p>
+        )}
+        <p>Priority: {project.priority}</p>
+        <p>Status: {project.status}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/projects/[projectId]/update/page.tsx
+++ b/app/(protected)/projects/[projectId]/update/page.tsx
@@ -1,0 +1,34 @@
+import { getProjectById } from '@/data/projects';
+import { requireUser } from '@/hooks/require-user';
+import EditProjectForm from '@/components/edit-project';
+import { notFound } from 'next/navigation';
+import React from 'react';
+
+interface UpdateProjectPageProps {
+  params: { projectId: string };
+}
+
+export default async function UpdateProjectPage({ params }: UpdateProjectPageProps) {
+  const session = await requireUser();
+  const project = await getProjectById(params.projectId, session.user.id as string);
+
+  if (!project) {
+    notFound();
+  }
+
+  const initialData = {
+    name: project.name,
+    description: project.description || '',
+    startDate: project.start_date || new Date(),
+    endDate: project.end_date || new Date(),
+    deadlineDate: project.deadline_date || new Date(),
+    customerId: project.customerId,
+    priority: project.priority,
+  } as const;
+
+  return (
+    <div className="container mx-auto py-10">
+      <EditProjectForm projectId={project.id} initialData={initialData} />
+    </div>
+  );
+}

--- a/app/api/projects/[projectId]/route.ts
+++ b/app/api/projects/[projectId]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
     }
 
     return NextResponse.json(project);
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       { error: 'Chyba serveru' },
       { status: 500 }

--- a/components/edit-project.tsx
+++ b/components/edit-project.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import * as z from "zod";
+import { useEffect, useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { CreateProjectSchema } from "@/schemas";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { updateProject } from "@/actions/projects/update-project";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { useRouter } from "next/navigation";
+import { Textarea } from "./ui/textarea";
+import { Calendar } from "./ui/calendar";
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { CalendarIcon } from "lucide-react";
+import { format } from "date-fns";
+
+interface EditProjectFormProps {
+  projectId: string;
+  initialData: z.infer<typeof CreateProjectSchema>;
+  onSuccess?: () => void;
+}
+
+const EditProjectForm = ({ projectId, initialData, onSuccess }: EditProjectFormProps) => {
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const [isPending, startTransition] = useTransition();
+  const [customers, setCustomers] = useState<{ id: string; name: string }[]>([]);
+
+  useEffect(() => {
+    const fetchCustomers = async () => {
+      try {
+        const response = await fetch("/api/customers");
+        if (!response.ok) {
+          throw new Error("Failed to fetch customers");
+        }
+        const data = await response.json();
+        setCustomers(data);
+      } catch (error) {
+        console.error("Error fetching customers:", error);
+      }
+    };
+
+    fetchCustomers();
+  }, []);
+
+  const form = useForm<z.infer<typeof CreateProjectSchema>>({
+    resolver: zodResolver(CreateProjectSchema),
+    defaultValues: initialData,
+  });
+
+  const onSubmit = (values: z.infer<typeof CreateProjectSchema>) => {
+    startTransition(() => {
+      updateProject(projectId, values)
+        .then((data: { error?: string; success?: string }) => {
+          if (data?.error) {
+            toast({
+              variant: "destructive",
+              title: "Chyba při aktualizaci projektu",
+              description: data.error,
+            });
+          }
+          if (data?.success) {
+            toast({
+              variant: "success",
+              title: data.success,
+            });
+            onSuccess?.();
+            router.push(`/dashboard`);
+          }
+        })
+        .catch(() => {
+          toast({
+            variant: "destructive",
+            title: "Nastala neočekávaná chyba",
+            description: "Prosím zkuste to znovu později",
+          });
+        });
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <p className="text-lg font-semibold">Edit Project</p>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <input
+                        {...field}
+                        disabled={isPending}
+                        className="input input-bordered w-full"
+                        placeholder="Enter project name"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Popis</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        disabled={isPending}
+                        placeholder="Zadej popis projektu"
+                        className="textarea textarea-bordered w-full"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="customerId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Customer</FormLabel>
+                    <FormControl>
+                      <Select disabled={isPending} onValueChange={field.onChange} value={field.value}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select a customer" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {customers?.map((customer) => (
+                            <SelectItem key={customer.id} value={customer.id}>
+                              {customer.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="startDate"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>Start Date</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className={cn(
+                              "w-full pl-3 text-left font-normal",
+                              !field.value && "text-muted-foreground"
+                            )}
+                            disabled={isPending}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {field.value instanceof Date && !isNaN(field.value.getTime())
+                              ? format(field.value, "dd.MM.yyyy")
+                              : "Vyber datum"}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={field.value}
+                          onSelect={field.onChange}
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="endDate"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>End Date</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className={cn(
+                              "w-full pl-3 text-left font-normal",
+                              !field.value && "text-muted-foreground"
+                            )}
+                            disabled={isPending}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {field.value ? format(field.value, "dd.MM.yyyy") : "Vyber datum"}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={field.value}
+                          onSelect={field.onChange}
+                          disabled={(date) => {
+                            const startDate = form.getValues("startDate") || new Date();
+                            return date < startDate;
+                          }}
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="deadlineDate"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>Deadline Date</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className={cn(
+                              "w-full pl-3 text-left font-normal",
+                              !field.value && "text-muted-foreground"
+                            )}
+                            disabled={isPending}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {field.value ? format(field.value, "dd.MM.yyyy") : "Vyber datum"}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={field.value}
+                          onSelect={field.onChange}
+                          disabled={(date) => date < new Date()}
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="priority"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Priority</FormLabel>
+                    <FormControl>
+                      <Select disabled={isPending} onValueChange={field.onChange} value={field.value}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select priority" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="LOW">Low</SelectItem>
+                          <SelectItem value="MEDIUM">Medium</SelectItem>
+                          <SelectItem value="HIGH">High</SelectItem>
+                          <SelectItem value="URGENT">Urgent</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <Button disabled={isPending} className="w-full" type="submit">
+              Update
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EditProjectForm;


### PR DESCRIPTION
## Summary
- implement server actions to update and delete projects
- add pages for project details, update and delete
- create EditProjectForm component for updating projects
- fix unused variable warning in project API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68415da1df208322ae41a8278d0a995c